### PR TITLE
Authenticate the Ceramic instance attached to the WebClient by default

### DIFF
--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -28,7 +28,7 @@ export class WebClient<
     return this.#threeId
   }
 
-  async authenticate(authProvider: EthereumAuthProvider, attachToCeramic = false): Promise<DID> {
+  async authenticate(authProvider: EthereumAuthProvider, attachToCeramic = true): Promise<DID> {
     const did = await this.connect(authProvider)
     await did.authenticate()
     if (attachToCeramic) {

--- a/packages/web/test/client.test.ts
+++ b/packages/web/test/client.test.ts
@@ -63,14 +63,14 @@ describe('WebClient', () => {
 
       expect(did).toBe(DIDInstance)
       expect(authenticate).toBeCalled()
-      expect(client.ceramic.did).toBeUndefined()
+      expect(client.ceramic.did).toBe(did)
     })
 
-    test('optionally attaches the DID to the Ceramic instance', async () => {
+    test('does not attach the DID to the Ceramic instance', async () => {
       const client = new WebClient({ ceramic: 'local' })
       const authProvider = new EthereumAuthProvider({}, '0x123456')
-      const did = await client.authenticate(authProvider, true)
-      expect(client.ceramic.did).toBe(did)
+      await client.authenticate(authProvider, false)
+      expect(client.ceramic.did).toBeUndefined()
     })
   })
 })

--- a/packages/web/test/self.test.ts
+++ b/packages/web/test/self.test.ts
@@ -1,14 +1,15 @@
+import { CeramicClient } from '@ceramicnetwork/http-client'
 import { DIDDataStore } from '@glazed/did-datastore'
-import { DID } from 'dids'
+import type { DID } from 'dids'
 
 import { SelfID, WebClient } from '../src'
 
+const Ceramic = CeramicClient as jest.Mock<CeramicClient>
 const DataStore = DIDDataStore as jest.Mock<DIDDataStore>
-const ID = DID as jest.Mock<DID>
 
 jest.mock('@3id/connect')
+jest.mock('@ceramicnetwork/http-client')
 jest.mock('@glazed/did-datastore')
-jest.mock('dids')
 
 describe('SelfID', () => {
   beforeEach(() => {
@@ -17,34 +18,60 @@ describe('SelfID', () => {
 
   describe('constructor', () => {
     test('throws an error if the provided DID instance is not authenticated', () => {
-      const client = new WebClient({ ceramic: 'local' })
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: false } } as unknown as CeramicClient)
+      )
 
-      ID.mockImplementationOnce(() => ({ authenticated: false } as unknown as DID))
-      const did1 = new ID()
-      expect(() => new SelfID({ client, did: did1 })).toThrow(
+      expect(() => new SelfID({ client: new WebClient({ ceramic: 'local' }) })).toThrow(
         'Input DID must be authenticated, use SelfID.authenticate() instead of new SelfID()'
       )
 
-      ID.mockImplementationOnce(() => ({ authenticated: true } as unknown as DID))
-      const did2 = new ID()
-      expect(() => new SelfID({ client, did: did2 })).not.toThrow()
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: true } } as unknown as CeramicClient)
+      )
+      expect(() => new SelfID({ client: new WebClient({ ceramic: 'local' }) })).not.toThrow()
     })
   })
 
   describe('getters', () => {
     test('client', () => {
-      ID.mockImplementationOnce(() => ({ authenticated: true } as unknown as DID))
-      const did = new ID()
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: true } } as unknown as CeramicClient)
+      )
       const client = new WebClient({ ceramic: 'local' })
-      const self = new SelfID({ client, did })
+      const self = new SelfID({ client })
       expect(self.client).toBe(client)
     })
 
+    describe('did', () => {
+      test('throws if there is no authenticated DID', () => {
+        // Need to use authenticated DID in constructor, otherwise it will throw there
+        const ceramic = {
+          did: { authenticated: true, id: 'did:3:123' },
+        } as unknown as CeramicClient
+        Ceramic.mockImplementationOnce(() => ceramic)
+        const self = new SelfID({ client: new WebClient({ ceramic: 'local' }) })
+
+        ceramic.did = { authenticated: false } as unknown as DID
+        expect(() => self.did).toThrow(
+          'Expected authenticated DID instance to be attached to Ceramic'
+        )
+      })
+
+      test('returns the authenticed DID', () => {
+        const did = { authenticated: true, id: 'did:3:123' }
+        Ceramic.mockImplementationOnce(() => ({ did } as unknown as CeramicClient))
+        const self = new SelfID({ client: new WebClient({ ceramic: 'local' }) })
+        expect(self.did).toBe(did)
+      })
+    })
+
     test('id', () => {
-      ID.mockImplementationOnce(() => ({ authenticated: true, id: 'did:3:123' } as unknown as DID))
-      const did = new ID()
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: true, id: 'did:3:123' } } as unknown as CeramicClient)
+      )
       const client = new WebClient({ ceramic: 'local' })
-      const self = new SelfID({ client, did })
+      const self = new SelfID({ client })
       expect(self.id).toBe('did:3:123')
     })
   })
@@ -52,12 +79,13 @@ describe('SelfID', () => {
   describe('get()', () => {
     test('calls dataStore.get()', async () => {
       const get = jest.fn(() => Promise.resolve({ name: 'Bob' }))
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: true, id: 'did:3:123' } } as unknown as CeramicClient)
+      )
       DataStore.mockImplementationOnce(() => ({ get } as unknown as DIDDataStore))
-      ID.mockImplementationOnce(() => ({ authenticated: true, id: 'did:3:123' } as unknown as DID))
 
       const client = new WebClient({ ceramic: 'local' })
-      const did = new ID()
-      const self = new SelfID({ client, did })
+      const self = new SelfID({ client })
 
       await expect(self.get('basicProfile')).resolves.toEqual({ name: 'Bob' })
       expect(get).toBeCalledWith('basicProfile', 'did:3:123')
@@ -67,12 +95,13 @@ describe('SelfID', () => {
   describe('set()', () => {
     test('calls dataStore.set()', async () => {
       const set = jest.fn(() => 'streamID')
+      Ceramic.mockImplementationOnce(
+        () => ({ did: { authenticated: true } } as unknown as CeramicClient)
+      )
       DataStore.mockImplementationOnce(() => ({ set } as unknown as DIDDataStore))
-      ID.mockImplementationOnce(() => ({ authenticated: true } as unknown as DID))
 
       const client = new WebClient({ ceramic: 'local' })
-      const did = new ID()
-      const self = new SelfID({ client, did })
+      const self = new SelfID({ client })
 
       await expect(self.set('basicProfile', { name: 'Bob' })).resolves.toBe('streamID')
       expect(set).toBeCalledWith('basicProfile', { name: 'Bob' })


### PR DESCRIPTION
Should be simpler for most use-cases, as a `SelfID` instance uses the Ceramic instance of the `WebClient`.